### PR TITLE
Add rendering of request notes

### DIFF
--- a/app/components/ride-row.js
+++ b/app/components/ride-row.js
@@ -8,6 +8,8 @@ export default Ember.Component.extend({
 
   tagName: '',
 
+  showNotes: false,
+
   cancellationIcon: Ember.computed('ride.cancellationReason', function() {
     const reason = this.get('ride.cancellationReason');
     const icon = reasonToIcon[reason];
@@ -63,6 +65,10 @@ export default Ember.Component.extend({
 
       ride.set('carOwner', carOwner);
       return ride.save();
+    },
+
+    toggleNotes() {
+      this.toggleProperty('showNotes');
     }
   }
 });

--- a/app/components/ride-row.js
+++ b/app/components/ride-row.js
@@ -8,8 +8,6 @@ export default Ember.Component.extend({
 
   tagName: '',
 
-  showNotes: false,
-
   cancellationIcon: Ember.computed('ride.cancellationReason', function() {
     const reason = this.get('ride.cancellationReason');
     const icon = reasonToIcon[reason];
@@ -65,10 +63,6 @@ export default Ember.Component.extend({
 
       ride.set('carOwner', carOwner);
       return ride.save();
-    },
-
-    toggleNotes() {
-      this.toggleProperty('showNotes');
     }
   }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -72,6 +72,10 @@ md-sidenav {
   }
 }
 
+.rides table .notes td {
+  border-top: 0
+}
+
 md-table-container.debts .person .name {
   font-weight: bold;
 }

--- a/app/templates/components/ride-row.hbs
+++ b/app/templates/components/ride-row.hbs
@@ -46,5 +46,10 @@
     {{#paper-button iconButton=true aria-label='Edit ride' title='Edit ride' class='edit' onClick=(action editRide ride)}}
       {{paper-icon 'mode edit'}}
     {{/paper-button}}
+    {{#if ride.requestNotes}}
+      {{#paper-button iconButton=true aria-label='View request note' title='View request note' class='note'}}
+        {{paper-icon 'comment'}}
+      {{/paper-button}}
+    {{/if}}
   {{/row.cell}}
 {{/body.row}}

--- a/app/templates/components/ride-row.hbs
+++ b/app/templates/components/ride-row.hbs
@@ -47,9 +47,14 @@
       {{paper-icon 'mode edit'}}
     {{/paper-button}}
     {{#if ride.requestNotes}}
-      {{#paper-button iconButton=true aria-label='View request note' title='View request note' class='note'}}
+      {{#paper-button iconButton=true aria-label='View request note' title='View request note' class='note' onClick=(action 'toggleNotes')}}
         {{paper-icon 'comment'}}
       {{/paper-button}}
     {{/if}}
   {{/row.cell}}
 {{/body.row}}
+{{#if showNotes}}
+  {{#body.row class='notes' as |row|}}
+    {{#row.cell class='notes'}}{{ride.requestNotes}}{{/row.cell}}
+  {{/body.row}}
+{{/if}}

--- a/app/templates/components/ride-row.hbs
+++ b/app/templates/components/ride-row.hbs
@@ -46,14 +46,9 @@
     {{#paper-button iconButton=true aria-label='Edit ride' title='Edit ride' class='edit' onClick=(action editRide ride)}}
       {{paper-icon 'mode edit'}}
     {{/paper-button}}
-    {{#if ride.requestNotes}}
-      {{#paper-button iconButton=true aria-label='View request note' title='View request note' class='note' onClick=(action 'toggleNotes')}}
-        {{paper-icon 'comment'}}
-      {{/paper-button}}
-    {{/if}}
   {{/row.cell}}
 {{/body.row}}
-{{#if showNotes}}
+{{#if ride.requestNotes}}
   {{#body.row class='notes' as |row|}}
     {{row.cell}}
     {{#row.cell class='notes' colspan=6}}{{ride.requestNotes}}{{/row.cell}}

--- a/app/templates/components/ride-row.hbs
+++ b/app/templates/components/ride-row.hbs
@@ -55,6 +55,7 @@
 {{/body.row}}
 {{#if showNotes}}
   {{#body.row class='notes' as |row|}}
-    {{#row.cell class='notes'}}{{ride.requestNotes}}{{/row.cell}}
+    {{row.cell}}
+    {{#row.cell class='notes' colspan=6}}{{ride.requestNotes}}{{/row.cell}}
   {{/body.row}}
 {{/if}}

--- a/tests/acceptance/rides-test.js
+++ b/tests/acceptance/rides-test.js
@@ -37,6 +37,8 @@ test('list existing rides with sortability, hiding cancelled ones by default', f
     passengers: 3,
     institution: leavenworth,
 
+    requestNotes: 'These are some request notes.',
+
     driver: sun,
     carOwner: lito
   });
@@ -76,6 +78,7 @@ test('list existing rides with sortability, hiding cancelled ones by default', f
     assert.equal(ride.institution, 'Fort Leavenworth');
     assert.equal(ride.address, '91 Albert');
     assert.equal(ride.contact, 'jorts@example.com');
+    assert.ok(ride.note.isVisible, 'expected the ride to show that it has a note');
 
     assert.equal(ride.driver.text, 'Sun');
     assert.equal(ride.carOwner.text, 'Lito');
@@ -96,6 +99,7 @@ test('list existing rides with sortability, hiding cancelled ones by default', f
     assert.ok(page.rides(1).enabled, 'expected the other ride to be enabled');
     assert.ok(page.rides(1).cancellation.showsNotCancelled, 'expected the other ride to not be cancelled');
     assert.equal(page.rides(1).name, 'Chelsea', 'expected the earlier ride to be sorted to the bottom');
+    assert.ok(page.rides(1).note.isHidden, 'expected the other ride to not have a note');
 
     assert.ok(page.rides(2).name, 'Visitor', 'expected the combined ride to be beneath its parent');
     assert.ok(page.rides(2).isCombined, 'expected the combined ride to show it is combined');

--- a/tests/acceptance/rides-test.js
+++ b/tests/acceptance/rides-test.js
@@ -82,6 +82,21 @@ test('list existing rides with sortability, hiding cancelled ones by default', f
 
     assert.equal(ride.driver.text, 'Sun');
     assert.equal(ride.carOwner.text, 'Lito');
+
+    assert.equal(page.notes().count, 0, 'expected no notes to be showing');
+  });
+
+  page.rides(0).note.click();
+
+  andThen(() => {
+    assert.equal(page.notes().count, 1, 'expected the notes to be showing');
+    assert.equal(page.notes(0).text, 'These are some request notes.');
+  });
+
+  page.rides(0).note.click();
+
+  andThen(() => {
+    assert.equal(page.notes().count, 0, 'expected the notes to be hiding again');
   });
 
   page.rides(0).edit();

--- a/tests/pages/rides.js
+++ b/tests/pages/rides.js
@@ -85,6 +85,14 @@ export default create({
     }
   }),
 
+  notes: collection({
+    itemScope: 'tr.notes',
+
+    item: {
+      text: text('td.notes')
+    }
+  }),
+
   form: {
     scope: '.md-dialog-container',
 

--- a/tests/pages/rides.js
+++ b/tests/pages/rides.js
@@ -72,11 +72,7 @@ export default create({
 
       isCombined: isVisible('.driver-and-car-owner md-icon[md-font-icon="call split"]'),
 
-      edit: clickable('button.edit'),
-
-      note: {
-        scope: 'button.note'
-      }
+      edit: clickable('button.edit')
     },
 
     head: {

--- a/tests/pages/rides.js
+++ b/tests/pages/rides.js
@@ -72,7 +72,11 @@ export default create({
 
       isCombined: isVisible('.driver-and-car-owner md-icon[md-font-icon="call split"]'),
 
-      edit: clickable('button.edit')
+      edit: clickable('button.edit'),
+
+      note: {
+        scope: 'button.note'
+      }
     },
 
     head: {


### PR DESCRIPTION
This closes #2. In discussion with interested parties, we decided that it made
more sense to always show notes, since they will be relatively rare when the
cancellation reasons are removed from them.